### PR TITLE
fix: ignore lint for one function and add workflow to test PRs

### DIFF
--- a/.github/workflows/pull-request-testing.yml
+++ b/.github/workflows/pull-request-testing.yml
@@ -1,0 +1,22 @@
+name: Pull request testing
+
+on:
+  pull_request
+
+jobs:
+  release:
+    name: 'Run linter and tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13
+      - name: Install dependencies
+        run: npm ci
+      - name: Run linter
+        run: npm run lint
+      - name: Run tests
+        run: npm test

--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -112,6 +112,7 @@ filter.oneLine = oneLine;
  * @returns {string} JSDoc compatible entry
  */
 function docline(field, fieldName, scopePropName) {
+  /* eslint-disable sonarjs/cognitive-complexity */
   const buildLine = (f, fName, pName) => {
     const type = f.type() ? f.type() : 'string';
     const description = f.description() ? ` - ${f.description().replace(/\r?\n|\r/g, '')}` : '';


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- `docline` was moved over from a template and there is no time now to dig into the ocean of recursion trying to refactor it
- add testing and linting on PR to not have issues with release worklow like we have now

Follow-up ticket https://github.com/asyncapi/generator-filters/issues/3