### PR TITLE
feat: support circular refs in generateExample

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,7 +70,7 @@ Generate string with example from provided schema
 
 **Kind**: global function  
 **Schema**: <code>object</code> - Schema object as JSON and not Schema model map  
-**Schema**: <code>object</code> - Options object. Supported options are listed here https://github.com/Redocly/openapi-sampler#usage  
+**Options**: <code>object</code> - Options object. Supported options are listed here https://github.com/Redocly/openapi-sampler#usage  
 <a name="oneLine"></a>
 
 ## oneLine() ⇒ <code>string</code>

--- a/docs/api.md
+++ b/docs/api.md
@@ -69,7 +69,8 @@ Extracts example from the message header
 Generate string with example from provided schema
 
 **Kind**: global function  
-**Msg**: <code>object</code> - A OpenAPI Schema Object  
+**Schema**: <code>object</code> - Schema object as JSON and not Schema model map  
+**Schema**: <code>object</code> - Options object. Supported options are listed here https://github.com/Redocly/openapi-sampler#usage  
 <a name="oneLine"></a>
 
 ## oneLine() ⇒ <code>string</code>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7277,8 +7277,9 @@
       }
     },
     "openapi-sampler": {
-      "version": "https://github.com/derberg/openapi-sampler/tarball/circular-refs",
-      "integrity": "sha512-4Hpyq2FNi9LEobOVaab1CdwGLV9t2SmS99lQIETzoz+FPRp4l2RqaOwF7gmHH2meuYDg0fWGank1EDspWElfZQ==",
+      "version": "1.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.17.tgz",
+      "integrity": "sha512-xYGPaPaEQFFAGQVrRpunkb8loNfL1rq4fJ+q7NH+LVBsrHKGUicD2f5Rzw6fWcRwwcOvnKD/aik9guiNWq2kpA==",
       "requires": {
         "json-pointer": "^0.6.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7277,9 +7277,8 @@
       }
     },
     "openapi-sampler": {
-      "version": "1.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.15.tgz",
-      "integrity": "sha512-wUD/vD3iBHKik/sME3uwUu4X3HFA53rDrPcVvLzgEELjHLbnTpSYfm4Jo9qZT1dPfBRowAnrF/VRQfOjL5QRAw==",
+      "version": "https://github.com/derberg/openapi-sampler/tarball/circular-refs",
+      "integrity": "sha512-Vk38WMxZh1sHhfFYeNm0LBnQq04wLXms8ysypj8SWG7byNYB9+HGH09Lr/4OqdLuCZ+XowCicKvvzgRAazTgkA==",
       "requires": {
         "json-pointer": "^0.6.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7278,7 +7278,7 @@
     },
     "openapi-sampler": {
       "version": "https://github.com/derberg/openapi-sampler/tarball/circular-refs",
-      "integrity": "sha512-Vk38WMxZh1sHhfFYeNm0LBnQq04wLXms8ysypj8SWG7byNYB9+HGH09Lr/4OqdLuCZ+XowCicKvvzgRAazTgkA==",
+      "integrity": "sha512-4Hpyq2FNi9LEobOVaab1CdwGLV9t2SmS99lQIETzoz+FPRp4l2RqaOwF7gmHH2meuYDg0fWGank1EDspWElfZQ==",
       "requires": {
         "json-pointer": "^0.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "lodash": "^4.17.15",
     "markdown-it": "^10.0.0",
-    "openapi-sampler": "^1.0.0-beta.15"
+    "openapi-sampler": "https://github.com/derberg/openapi-sampler/tarball/circular-refs"
   },
   "ava": {
     "files": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "lodash": "^4.17.15",
     "markdown-it": "^10.0.0",
-    "openapi-sampler": "https://github.com/derberg/openapi-sampler/tarball/circular-refs"
+    "openapi-sampler": "1.0.0-beta.17"
   },
   "ava": {
     "files": [

--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -69,11 +69,11 @@ filter.getHeadersExamples = getHeadersExamples;
 /**
  * Generate string with example from provided schema
  * @schema {object} - Schema Object
- * @asyncapi {object} - Whole AsyncAPI object used for handling circular refs
+ * @schema {object} - Options object. Supported options are listed here https://github.com/Redocly/openapi-sampler#usage
  * @returns {string}
  */
-function generateExample(schema, asyncapi) {
-  return JSON.stringify(OpenAPISampler.sample(schema, {}, asyncapi) || '', null, 2);
+function generateExample(schema, options) {
+  return JSON.stringify(OpenAPISampler.sample(schema, options || {}) || '', null, 2);
 };
 filter.generateExample = generateExample;
 

--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -68,11 +68,12 @@ filter.getHeadersExamples = getHeadersExamples;
 
 /**
  * Generate string with example from provided schema
- * @msg {object} - A OpenAPI Schema Object
+ * @schema {object} - Schema Object
+ * @asyncapi {object} - Whole AsyncAPI object used for handling circular refs
  * @returns {string}
  */
 function generateExample(schema, asyncapi) {
-  return JSON.stringify(OpenAPISampler.sample(schema, asyncapi) || '', null, 2);
+  return JSON.stringify(OpenAPISampler.sample(schema, {}, asyncapi) || '', null, 2);
 };
 filter.generateExample = generateExample;
 

--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -68,7 +68,7 @@ filter.getHeadersExamples = getHeadersExamples;
 
 /**
  * Generate string with example from provided schema
- * @schema {object} - Schema Object
+ * @schema {object} - Schema object as JSON and not Schema model map
  * @schema {object} - Options object. Supported options are listed here https://github.com/Redocly/openapi-sampler#usage
  * @returns {string}
  */

--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -71,8 +71,8 @@ filter.getHeadersExamples = getHeadersExamples;
  * @msg {object} - A OpenAPI Schema Object
  * @returns {string}
  */
-function generateExample(schema) {
-  return JSON.stringify(OpenAPISampler.sample(schema) || '', null, 2);
+function generateExample(schema, asyncapi) {
+  return JSON.stringify(OpenAPISampler.sample(schema, asyncapi) || '', null, 2);
 };
 filter.generateExample = generateExample;
 

--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -69,7 +69,7 @@ filter.getHeadersExamples = getHeadersExamples;
 /**
  * Generate string with example from provided schema
  * @schema {object} - Schema object as JSON and not Schema model map
- * @schema {object} - Options object. Supported options are listed here https://github.com/Redocly/openapi-sampler#usage
+ * @options {object} - Options object. Supported options are listed here https://github.com/Redocly/openapi-sampler#usage
  * @returns {string}
  */
 function generateExample(schema, options) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- support circular refs in generateExample

It doesn't work yet as expected, OpenAPISampler doesn't support fully dereferenced objects yet

**Related issue(s)**
Fixes https://github.com/asyncapi/parser-js/issues/83