### PR TITLE
refactor: Remove unnecessary semicolons from custom filters

### DIFF
--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -46,7 +46,7 @@ function getPayloadExamples(msg) {
   if (msg.payload() && msg.payload().examples()) {
     return msg.payload().examples();
   }
-};
+}
 filter.getPayloadExamples = getPayloadExamples;
 
 /**
@@ -63,7 +63,7 @@ function getHeadersExamples(msg) {
   if (msg.headers() && msg.headers().examples()) {
     return msg.headers().examples();
   }
-};
+}
 filter.getHeadersExamples = getHeadersExamples;
 
 /**
@@ -74,7 +74,7 @@ filter.getHeadersExamples = getHeadersExamples;
  */
 function generateExample(schema, options) {
   return JSON.stringify(OpenAPISampler.sample(schema, options || {}) || '', null, 2);
-};
+}
 filter.generateExample = generateExample;
 
 /**
@@ -85,7 +85,7 @@ filter.generateExample = generateExample;
 function oneLine(str) {
   if (!str) return str;
   return str.replace(/\n/g, ' ');
-};
+}
 filter.oneLine = oneLine;
 
 /**
@@ -142,5 +142,5 @@ function docline(field, fieldName, scopePropName) {
   };
 
   return buildLine(field, fieldName, scopePropName);
-};
+}
 filter.docline = docline;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Removed the semicolon in line generator-filters/blob/master/src/customFilters.js#L49
- Removed the semicolon in line generator-filters/blob/master/src/customFilters.js#L66
- Removed the semicolon in line generator-filters/blob/master/src/customFilters.js#L77
- Removed the semicolon in line generator-filters/blob/master/src/customFilters.js#L88
- Removed the semicolon in line generator-filters/blob/master/src/customFilters.js#L145


**Related issue(s)**
Resolves #11 