### PR TITLE
feat!: support 2.1.0 version of spec

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -95,6 +95,7 @@ rules:
   prefer-template: 2
 
 overrides:
-- files: "src/customFilters.test.js"
-  rules:
-    sonarjs/no-duplicate-string: 0
+  - files:
+      - "src/customFilters.test.js"
+     rules:
+      sonarjs/no-duplicate-string: 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -93,3 +93,8 @@ rules:
   prefer-const: 2
   prefer-spread: 2
   prefer-template: 2
+
+overrides:
+- files: "**/*.test.js"
+  rules:
+    sonarjs/no-duplicate-string: 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -97,5 +97,5 @@ rules:
 overrides:
   - files:
       - "src/customFilters.test.js"
-     rules:
+    rules:
       sonarjs/no-duplicate-string: 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -93,3 +93,8 @@ rules:
   prefer-const: 2
   prefer-spread: 2
   prefer-template: 2
+
+overrides:
+- files: "src/customFilters.test.js"
+  rules:
+    sonarjs/no-duplicate-string: 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -93,8 +93,3 @@ rules:
   prefer-const: 2
   prefer-spread: 2
   prefer-template: 2
-
-overrides:
-- files: "**/*.test.js"
-  rules:
-    sonarjs/no-duplicate-string: 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -93,9 +93,3 @@ rules:
   prefer-const: 2
   prefer-spread: 2
   prefer-template: 2
-
-overrides:
-  - files:
-      - "src/customFilters.test.js"
-    rules:
-      sonarjs/no-duplicate-string: 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,13 +34,13 @@
       }
     },
     "@asyncapi/parser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.6.0.tgz",
-      "integrity": "sha512-uLLoDn0Enisp7JgZV6TdK7AfbQF0dxS4j68XGjoslTew/OGfAatchpuP5ARMcxqnygYyhtEFcOd/qzKbmZy2zA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.7.0.tgz",
+      "integrity": "sha512-ULL6k+s1zzeLLCUH2l0nsTxtCdiUdnAkMROhXD5XnEAIN+3M3tYO39w9HcbzKHngxFFhr0MsHOrGpw61rcxIsw==",
       "dev": true,
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@asyncapi/specs": "^2.7.8",
+        "@asyncapi/specs": "2.8.0",
         "@fmvilas/pseudo-yaml-ast": "^0.3.1",
         "ajv": "^6.10.1",
         "js-yaml": "^3.13.1",
@@ -51,9 +51,9 @@
       }
     },
     "@asyncapi/specs": {
-      "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.8.tgz",
-      "integrity": "sha512-GvyUo8rKAY25XdhM2dYqv4yf6gzgiNRazLxbeQfeD5oXu4aEs/rkpcgHPeb3ckA6xXiyzdBnpVYhJOcPvgr46g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.8.0.tgz",
+      "integrity": "sha512-ZVyr1L0Le8Z0mvr2BPriszaDu53rZxevjqVCXt3PqJMPJuiiGMVhkslmclj474nBK0ckygSRe8jAd4smm9XOrg==",
       "dev": true
     },
     "@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,58 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@asyncapi/parser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.6.0.tgz",
+      "integrity": "sha512-uLLoDn0Enisp7JgZV6TdK7AfbQF0dxS4j68XGjoslTew/OGfAatchpuP5ARMcxqnygYyhtEFcOd/qzKbmZy2zA==",
+      "dev": true,
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@asyncapi/specs": "^2.7.8",
+        "@fmvilas/pseudo-yaml-ast": "^0.3.1",
+        "ajv": "^6.10.1",
+        "js-yaml": "^3.13.1",
+        "json-to-ast": "^2.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "node-fetch": "^2.6.0",
+        "tiny-merge-patch": "^0.1.2"
+      }
+    },
+    "@asyncapi/specs": {
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.8.tgz",
+      "integrity": "sha512-GvyUo8rKAY25XdhM2dYqv4yf6gzgiNRazLxbeQfeD5oXu4aEs/rkpcgHPeb3ckA6xXiyzdBnpVYhJOcPvgr46g==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -104,6 +156,21 @@
           "dev": true
         }
       }
+    },
+    "@fmvilas/pseudo-yaml-ast": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@fmvilas/pseudo-yaml-ast/-/pseudo-yaml-ast-0.3.1.tgz",
+      "integrity": "sha512-8OAB74W2a9M3k9bjYD8AjVXkX+qO8c0SqNT5HlgOqx7AxSw8xdksEcZp7gFtfi+4njSxT6+76ZR+1ubjAwQHOg==",
+      "dev": true,
+      "requires": {
+        "yaml-ast-parser": "0.0.43"
+      }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -505,6 +572,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -971,6 +1044,12 @@
         }
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1154,6 +1233,12 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "code-error-fragment": {
+      "version": "0.0.230",
+      "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
+      "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw==",
+      "dev": true
     },
     "code-excerpt": {
       "version": "2.1.1",
@@ -2489,6 +2574,12 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -3079,6 +3170,16 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json-to-ast": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
+      "integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
+      "dev": true,
+      "requires": {
+        "code-error-fragment": "0.0.230",
+        "grapheme-splitter": "^1.0.4"
+      }
     },
     "jsonfile": {
       "version": "6.0.1",
@@ -8932,6 +9033,12 @@
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
       "dev": true
     },
+    "tiny-merge-patch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tiny-merge-patch/-/tiny-merge-patch-0.1.2.tgz",
+      "integrity": "sha1-Lo3tGcVuoV29OtTtXbHI5a1UTDw=",
+      "dev": true
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -9293,6 +9400,12 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
       "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
+    },
+    "yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -33,15 +33,16 @@
   },
   "homepage": "https://github.com/asyncapi/generator-filters#readme",
   "devDependencies": {
-    "ava": "^3.7.0",
-    "eslint": "^6.8.0",
-    "eslint-plugin-sonarjs": "^0.5.0",
-    "jsdoc-to-markdown": "^5.0.3",
+    "@asyncapi/parser": "^1.6.0",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/github": "^7.0.4",
     "@semantic-release/npm": "^7.0.3",
     "@semantic-release/release-notes-generator": "^9.0.1",
+    "ava": "^3.7.0",
     "conventional-changelog-conventionalcommits": "^4.2.3",
+    "eslint": "^6.8.0",
+    "eslint-plugin-sonarjs": "^0.5.0",
+    "jsdoc-to-markdown": "^5.0.3",
     "semantic-release": "^17.0.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/asyncapi/generator-filters#readme",
   "devDependencies": {
-    "@asyncapi/parser": "^1.6.0",
+    "@asyncapi/parser": "^1.7.0",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/github": "^7.0.4",
     "@semantic-release/npm": "^7.0.3",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.exclusions=src/customFilters.test.js,src/lodashFilters.test.js

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,1 @@
-sonar.exclusions = src/*.test.js
+sonar.exclusions=src/customFilters.test.js,src/lodashFilters.test.js

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions = src/*.test.js

--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -61,8 +61,6 @@ function getPayloadExamples(msg) {
   if (payload && payload.examples()) {
     return payload.examples().map(example => ({ example }));
   }
-
-  return;
 }
 filter.getPayloadExamples = getPayloadExamples;
 
@@ -95,8 +93,6 @@ function getHeadersExamples(msg) {
   if (headers && headers.examples()) {
     return headers.examples().map(example => ({ example }));
   }
-
-  return;
 }
 filter.getHeadersExamples = getHeadersExamples;
 

--- a/src/customFilters.js
+++ b/src/customFilters.js
@@ -38,14 +38,31 @@ filter.logError = logError;
  * @returns {object}
  */
 function getPayloadExamples(msg) {
-  if (Array.isArray(msg.examples()) && msg.examples().find(e => e.payload)) {
+  const examples = msg.examples();
+  if (Array.isArray(examples) && examples.some(e => e.payload)) {
     // Instead of flat or flatmap use this.
-    return _.flatMap(msg.examples().map(e => e.payload).filter(Boolean));
+    const messageExamples = _.flatMap(examples)
+      .map(e => {
+        if (!e.payload) return;
+        return {
+          name: e.name,
+          summary: e.summary,
+          example: e.payload,
+        };
+      })
+      .filter(Boolean);
+
+    if (messageExamples.length > 0) {
+      return messageExamples;
+    }
   }
-  
-  if (msg.payload() && msg.payload().examples()) {
-    return msg.payload().examples();
+
+  const payload = msg.payload();
+  if (payload && payload.examples()) {
+    return payload.examples().map(example => ({ example }));
   }
+
+  return;
 }
 filter.getPayloadExamples = getPayloadExamples;
 
@@ -55,14 +72,31 @@ filter.getPayloadExamples = getPayloadExamples;
  * @returns {object}
  */
 function getHeadersExamples(msg) {
-  if (Array.isArray(msg.examples()) && msg.examples().find(e => e.headers)) {
+  const examples = msg.examples();
+  if (Array.isArray(examples) && examples.some(e => e.headers)) {
     // Instead of flat or flatmap use this.
-    return _.flatMap(msg.examples().map(e => e.headers).filter(Boolean));
+    const messageExamples = _.flatMap(examples)
+      .map(e => {
+        if (!e.headers) return;
+        return {
+          name: e.name,
+          summary: e.summary,
+          example: e.headers,
+        };
+      })
+      .filter(Boolean);
+
+    if (messageExamples.length > 0) {
+      return messageExamples;
+    }
   }
-  
-  if (msg.headers() && msg.headers().examples()) {
-    return msg.headers().examples();
+
+  const headers = msg.headers();
+  if (headers && headers.examples()) {
+    return headers.examples().map(example => ({ example }));
   }
+
+  return;
 }
 filter.getHeadersExamples = getHeadersExamples;
 

--- a/src/customFilters.test.js
+++ b/src/customFilters.test.js
@@ -5,6 +5,21 @@ const Message = require('@asyncapi/parser/lib/models/message');
 const exampleName = 'example name';
 const exampleSummary = 'example summary';
 
+function messageExampleMock(firstType = 'payload', secondType = 'payload') {
+  return [
+    {
+      name: exampleName,
+      summary: exampleSummary,
+      [firstType]: { foo: 'bar' },
+    },
+    {
+      name: exampleName,
+      summary: exampleSummary,
+      [secondType]: { bar: 'foo' },
+    },
+  ];
+}
+
 test('markdown2html returns valid html', t => {
   const is = t.is;
   const value =  markdown2html('**test**');
@@ -33,18 +48,7 @@ multiline`);
 test('.getPayloadExamples() should return empty examples', t => {
   const result = getPayloadExamples(
     new Message({
-      examples: [
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          headers: { foo: 'bar' },
-        },
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          headers: { bar: 'foo' },
-        },
-      ],
+      examples: messageExampleMock('headers', 'headers'),
     }),
   );
   t.is(result, undefined);
@@ -53,32 +57,10 @@ test('.getPayloadExamples() should return empty examples', t => {
 test('.getPayloadExamples() should return payload examples', t => {
   const result = getPayloadExamples(
     new Message({
-      examples: [
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          payload: { foo: 'bar' },
-        },
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          payload: { bar: 'foo' },
-        },
-      ],
+      examples: messageExampleMock('payload', 'payload'),
     }),
   );
-  t.deepEqual(result, [
-    {
-      name: exampleName,
-      summary: exampleSummary,
-      example: { foo: 'bar' },
-    },
-    {
-      name: exampleName,
-      summary: exampleSummary,
-      example: { bar: 'foo' },
-    },
-  ]);
+  t.deepEqual(result, messageExampleMock('example', 'example'));
 });
 
 test('.getPayloadExamples() should return examples from payload schema', t => {
@@ -105,18 +87,7 @@ test('.getPayloadExamples() should return examples from payload schema - case wh
       payload: {
         examples: [{ foo: 'bar' }, { bar: 'foo' }],
       },
-      examples: [
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          headers: { foo: 'bar' },
-        },
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          headers: { bar: 'foo' },
-        },
-      ],
+      examples: messageExampleMock('headers', 'headers'),
     }),
   );
   t.deepEqual(result, [
@@ -135,18 +106,7 @@ test('.getPayloadExamples() should return examples for payload - case when at le
       payload: {
         examples: [{ foo: 'bar' }, { bar: 'foo' }],
       },
-      examples: [
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          headers: { foo: 'bar' },
-        },
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          payload: { bar: 'foo' },
-        },
-      ],
+      examples: messageExampleMock('headers', 'payload'),
     }),
   );
   t.deepEqual(result, [
@@ -161,18 +121,7 @@ test('.getPayloadExamples() should return examples for payload - case when at le
 test('.getHeadersExamples() should return empty examples', t => {
   const result = getHeadersExamples(
     new Message({
-      examples: [
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          payload: { foo: 'bar' },
-        },
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          payload: { bar: 'foo' },
-        },
-      ],
+      examples: messageExampleMock('payload', 'payload'),
     }),
   );
   t.is(result, undefined);
@@ -181,32 +130,10 @@ test('.getHeadersExamples() should return empty examples', t => {
 test('.getHeadersExamples() should return headers examples', t => {
   const result = getHeadersExamples(
     new Message({
-      examples: [
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          headers: { foo: 'bar' },
-        },
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          headers: { bar: 'foo' },
-        },
-      ],
+      examples: messageExampleMock('headers', 'headers'),
     }),
   );
-  t.deepEqual(result, [
-    {
-      name: exampleName,
-      summary: exampleSummary,
-      example: { foo: 'bar' },
-    },
-    {
-      name: exampleName,
-      summary: exampleSummary,
-      example: { bar: 'foo' },
-    },
-  ]);
+  t.deepEqual(result, messageExampleMock('example', 'example'));
 });
 
 test('.getHeadersExamples() should return examples from headers schema', t => {
@@ -233,18 +160,7 @@ test('.getHeadersExamples() should return examples from headers schema - case wh
       headers: {
         examples: [{ foo: 'bar' }, { bar: 'foo' }],
       },
-      examples: [
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          payload: { foo: 'bar' },
-        },
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          payload: { bar: 'foo' },
-        },
-      ],
+      examples: messageExampleMock('payload', 'payload'),
     }),
   );
   t.deepEqual(result, [
@@ -263,18 +179,7 @@ test('.getHeadersExamples() should return examples for headers - case when at le
       headers: {
         examples: [{ foo: 'bar' }, { bar: 'foo' }],
       },
-      examples: [
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          payload: { foo: 'bar' },
-        },
-        {
-          name: exampleName,
-          summary: exampleSummary,
-          headers: { bar: 'foo' },
-        },
-      ],
+      examples: messageExampleMock('payload', 'headers'),
     }),
   );
   t.deepEqual(result, [

--- a/src/customFilters.test.js
+++ b/src/customFilters.test.js
@@ -30,7 +30,7 @@ multiline`);
   is(value, expected);
 });
 
-test('.getPayloadExamples() should return empty examples', t => { // NOSONAR
+test('.getPayloadExamples() should return empty examples', t => {
   const result = getPayloadExamples(
     new Message({
       examples: [

--- a/src/customFilters.test.js
+++ b/src/customFilters.test.js
@@ -30,7 +30,7 @@ multiline`);
   is(value, expected);
 });
 
-test('.getPayloadExamples() should return epmty examples', t => {
+test('.getPayloadExamples() should return empty examples', t => {
   const result = getPayloadExamples(
     new Message({
       examples: [
@@ -99,7 +99,7 @@ test('.getPayloadExamples() should return examples from payload schema', t => {
   ]);
 });
 
-test('.getPayloadExamples() should return examples from payload schema - case when headers examples are defined in `examples` field', t => {
+test('.getPayloadExamples() should return examples from payload schema - case when only headers examples are defined in `examples` field', t => {
   const result = getPayloadExamples(
     new Message({
       payload: {
@@ -129,7 +129,36 @@ test('.getPayloadExamples() should return examples from payload schema - case wh
   ]);
 });
 
-test('.getHeadersExamples() should return epmty examples', t => {
+test('.getPayloadExamples() should return examples for payload - case when at least one item in `examples` array has `payload` field with existing `payload.examples`', t => {
+  const result = getPayloadExamples(
+    new Message({
+      payload: {
+        examples: [{ foo: 'bar' }, { bar: 'foo' }],
+      },
+      examples: [
+        {
+          name: exampleName,
+          summary: exampleSummary,
+          headers: { foo: 'bar' },
+        },
+        {
+          name: exampleName,
+          summary: exampleSummary,
+          payload: { bar: 'foo' },
+        },
+      ],
+    }),
+  );
+  t.deepEqual(result, [
+    {
+      name: exampleName,
+      summary: exampleSummary,
+      example: { bar: 'foo' },
+    },
+  ]);
+});
+
+test('.getHeadersExamples() should return empty examples', t => {
   const result = getHeadersExamples(
     new Message({
       examples: [
@@ -198,7 +227,7 @@ test('.getHeadersExamples() should return examples from headers schema', t => {
   ]);
 });
 
-test('.getHeadersExamples() should return examples from headers schema - case when payload examples are defined in `examples` field', t => {
+test('.getHeadersExamples() should return examples from headers schema - case when only payload examples are defined in `examples` field', t => {
   const result = getHeadersExamples(
     new Message({
       headers: {
@@ -223,6 +252,35 @@ test('.getHeadersExamples() should return examples from headers schema - case wh
       example: { foo: 'bar' },
     },
     {
+      example: { bar: 'foo' },
+    },
+  ]);
+});
+
+test('.getHeadersExamples() should return examples for headers - case when at least one item in `examples` array has `headers` field with existing `headers.examples`', t => {
+  const result = getHeadersExamples(
+    new Message({
+      headers: {
+        examples: [{ foo: 'bar' }, { bar: 'foo' }],
+      },
+      examples: [
+        {
+          name: exampleName,
+          summary: exampleSummary,
+          payload: { foo: 'bar' },
+        },
+        {
+          name: exampleName,
+          summary: exampleSummary,
+          headers: { bar: 'foo' },
+        },
+      ],
+    }),
+  );
+  t.deepEqual(result, [
+    {
+      name: exampleName,
+      summary: exampleSummary,
       example: { bar: 'foo' },
     },
   ]);

--- a/src/customFilters.test.js
+++ b/src/customFilters.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 const test = require('ava');
 const { markdown2html, generateExample, getPayloadExamples, getHeadersExamples, oneLine } = require('./customFilters');
 const Message = require('@asyncapi/parser/lib/models/message');

--- a/src/customFilters.test.js
+++ b/src/customFilters.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable sonarjs/no-duplicate-string */
+// NOSONAR
 const test = require('ava');
 const { markdown2html, generateExample, getPayloadExamples, getHeadersExamples, oneLine } = require('./customFilters');
 const Message = require('@asyncapi/parser/lib/models/message');

--- a/src/customFilters.test.js
+++ b/src/customFilters.test.js
@@ -1,4 +1,3 @@
-// NOSONAR
 const test = require('ava');
 const { markdown2html, generateExample, getPayloadExamples, getHeadersExamples, oneLine } = require('./customFilters');
 const Message = require('@asyncapi/parser/lib/models/message');
@@ -31,7 +30,7 @@ multiline`);
   is(value, expected);
 });
 
-test('.getPayloadExamples() should return empty examples', t => {
+test('.getPayloadExamples() should return empty examples', t => { // NOSONAR
   const result = getPayloadExamples(
     new Message({
       examples: [

--- a/src/customFilters.test.js
+++ b/src/customFilters.test.js
@@ -1,5 +1,6 @@
 const test = require('ava');
-const {markdown2html, generateExample, oneLine} = require('./customFilters');
+const { markdown2html, generateExample, getPayloadExamples, getHeadersExamples, oneLine } = require('./customFilters');
+const Message = require('@asyncapi/parser/lib/models/message');
 
 test('markdown2html returns valid html', t => {
   const is = t.is;
@@ -24,4 +25,202 @@ multiline`);
   const expected = 'This is multiline';
   
   is(value, expected);
+});
+
+test('.getPayloadExamples() should return epmty examples', t => {
+  const result = getPayloadExamples(
+    new Message({
+      examples: [
+        {
+          name: 'example name',
+          summary: 'example summary',
+          headers: { foo: 'bar' },
+        },
+        {
+          name: 'example name',
+          summary: 'example summary',
+          headers: { bar: 'foo' },
+        },
+      ],
+    }),
+  );
+  t.is(result, undefined);
+});
+
+test('.getPayloadExamples() should return payload examples', t => {
+  const result = getPayloadExamples(
+    new Message({
+      examples: [
+        {
+          name: 'example name',
+          summary: 'example summary',
+          payload: { foo: 'bar' },
+        },
+        {
+          name: 'example name',
+          summary: 'example summary',
+          payload: { bar: 'foo' },
+        },
+      ],
+    }),
+  );
+  t.deepEqual(result, [
+    {
+      name: 'example name',
+      summary: 'example summary',
+      example: { foo: 'bar' },
+    },
+    {
+      name: 'example name',
+      summary: 'example summary',
+      example: { bar: 'foo' },
+    },
+  ]);
+});
+
+test('.getPayloadExamples() should return examples from payload schema', t => {
+  const result = getPayloadExamples(
+    new Message({
+      payload: {
+        examples: [{ foo: 'bar' }, { bar: 'foo' }],
+      },
+    }),
+  );
+  t.deepEqual(result, [
+    {
+      example: { foo: 'bar' },
+    },
+    {
+      example: { bar: 'foo' },
+    },
+  ]);
+});
+
+test('.getPayloadExamples() should return examples from payload schema - case when headers examples are defined in `examples` field', t => {
+  const result = getPayloadExamples(
+    new Message({
+      payload: {
+        examples: [{ foo: 'bar' }, { bar: 'foo' }],
+      },
+      examples: [
+        {
+          name: 'example name',
+          summary: 'example summary',
+          headers: { foo: 'bar' },
+        },
+        {
+          name: 'example name',
+          summary: 'example summary',
+          headers: { bar: 'foo' },
+        },
+      ],
+    }),
+  );
+  t.deepEqual(result, [
+    {
+      example: { foo: 'bar' },
+    },
+    {
+      example: { bar: 'foo' },
+    },
+  ]);
+});
+
+test('.getHeadersExamples() should return epmty examples', t => {
+  const result = getHeadersExamples(
+    new Message({
+      examples: [
+        {
+          name: 'example name',
+          summary: 'example summary',
+          payload: { foo: 'bar' },
+        },
+        {
+          name: 'example name',
+          summary: 'example summary',
+          payload: { bar: 'foo' },
+        },
+      ],
+    }),
+  );
+  t.is(result, undefined);
+});
+
+test('.getHeadersExamples() should return headers examples', t => {
+  const result = getHeadersExamples(
+    new Message({
+      examples: [
+        {
+          name: 'example name',
+          summary: 'example summary',
+          headers: { foo: 'bar' },
+        },
+        {
+          name: 'example name',
+          summary: 'example summary',
+          headers: { bar: 'foo' },
+        },
+      ],
+    }),
+  );
+  t.deepEqual(result, [
+    {
+      name: 'example name',
+      summary: 'example summary',
+      example: { foo: 'bar' },
+    },
+    {
+      name: 'example name',
+      summary: 'example summary',
+      example: { bar: 'foo' },
+    },
+  ]);
+});
+
+test('.getHeadersExamples() should return examples from headers schema', t => {
+  const result = getHeadersExamples(
+    new Message({
+      headers: {
+        examples: [{ foo: 'bar' }, { bar: 'foo' }],
+      },
+    }),
+  );
+  t.deepEqual(result, [
+    {
+      example: { foo: 'bar' },
+    },
+    {
+      example: { bar: 'foo' },
+    },
+  ]);
+});
+
+test('.getHeadersExamples() should return examples from headers schema - case when payload examples are defined in `examples` field', t => {
+  const result = getHeadersExamples(
+    new Message({
+      headers: {
+        examples: [{ foo: 'bar' }, { bar: 'foo' }],
+      },
+      examples: [
+        {
+          name: 'example name',
+          summary: 'example summary',
+          payload: { foo: 'bar' },
+        },
+        {
+          name: 'example name',
+          summary: 'example summary',
+          payload: { bar: 'foo' },
+        },
+      ],
+    }),
+  );
+  t.deepEqual(result, [
+    {
+      example: { foo: 'bar' },
+    },
+    {
+      example: { bar: 'foo' },
+    },
+  ]);
 });

--- a/src/customFilters.test.js
+++ b/src/customFilters.test.js
@@ -2,6 +2,9 @@ const test = require('ava');
 const { markdown2html, generateExample, getPayloadExamples, getHeadersExamples, oneLine } = require('./customFilters');
 const Message = require('@asyncapi/parser/lib/models/message');
 
+const exampleName = 'example name';
+const exampleSummary = 'example summary';
+
 test('markdown2html returns valid html', t => {
   const is = t.is;
   const value =  markdown2html('**test**');
@@ -32,13 +35,13 @@ test('.getPayloadExamples() should return epmty examples', t => {
     new Message({
       examples: [
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           headers: { foo: 'bar' },
         },
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           headers: { bar: 'foo' },
         },
       ],
@@ -52,13 +55,13 @@ test('.getPayloadExamples() should return payload examples', t => {
     new Message({
       examples: [
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           payload: { foo: 'bar' },
         },
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           payload: { bar: 'foo' },
         },
       ],
@@ -66,13 +69,13 @@ test('.getPayloadExamples() should return payload examples', t => {
   );
   t.deepEqual(result, [
     {
-      name: 'example name',
-      summary: 'example summary',
+      name: exampleName,
+      summary: exampleSummary,
       example: { foo: 'bar' },
     },
     {
-      name: 'example name',
-      summary: 'example summary',
+      name: exampleName,
+      summary: exampleSummary,
       example: { bar: 'foo' },
     },
   ]);
@@ -104,13 +107,13 @@ test('.getPayloadExamples() should return examples from payload schema - case wh
       },
       examples: [
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           headers: { foo: 'bar' },
         },
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           headers: { bar: 'foo' },
         },
       ],
@@ -131,13 +134,13 @@ test('.getHeadersExamples() should return epmty examples', t => {
     new Message({
       examples: [
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           payload: { foo: 'bar' },
         },
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           payload: { bar: 'foo' },
         },
       ],
@@ -151,13 +154,13 @@ test('.getHeadersExamples() should return headers examples', t => {
     new Message({
       examples: [
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           headers: { foo: 'bar' },
         },
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           headers: { bar: 'foo' },
         },
       ],
@@ -165,13 +168,13 @@ test('.getHeadersExamples() should return headers examples', t => {
   );
   t.deepEqual(result, [
     {
-      name: 'example name',
-      summary: 'example summary',
+      name: exampleName,
+      summary: exampleSummary,
       example: { foo: 'bar' },
     },
     {
-      name: 'example name',
-      summary: 'example summary',
+      name: exampleName,
+      summary: exampleSummary,
       example: { bar: 'foo' },
     },
   ]);
@@ -203,13 +206,13 @@ test('.getHeadersExamples() should return examples from headers schema - case wh
       },
       examples: [
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           payload: { foo: 'bar' },
         },
         {
-          name: 'example name',
-          summary: 'example summary',
+          name: exampleName,
+          summary: exampleSummary,
           payload: { bar: 'foo' },
         },
       ],


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- change the logic for `getPayloadExamples` and `getHeadersExamples` functions to support the `name` and `summary` fields from item of `message.examples`
- add tests
- install parser-js as dev-dependency, only for testing purpose.

**Related issue(s)**
Part of https://github.com/asyncapi/spec/issues/536